### PR TITLE
Update default Jupyter service name

### DIFF
--- a/jnmouse/utils/create_jupyter_service.py
+++ b/jnmouse/utils/create_jupyter_service.py
@@ -19,7 +19,7 @@ WantedBy=multi-user.target
 """
 
 
-JUPYTER_SERVICE_NAME = 'jetbot_jupyter'
+JUPYTER_SERVICE_NAME = 'jnmouse_jupyter'
 
 
 def get_jupyter_service(working_directory):
@@ -36,7 +36,7 @@ if __name__ == '__main__':
         type=str,
         help='The directory for Jupyter Lab',
         default=os.path.expanduser('~'))
-    parser.add_argument('--output', default='jetbot_jupyter.service')
+    parser.add_argument('--output', default='{}.service'.format(JUPYTER_SERVICE_NAME))
     args = parser.parse_args()
 
     with open(args.output, 'w') as f:


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

JupyterLabs用のサービスの名前を変更します

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

```
jetson@jnmouse:~/jnm_jupyternotebook$ cd jnmouse/utils/
jetson@jnmouse:~/jnm_jupyternotebook/jnmouse/utils$ python3 create_jupyter_service.py --working_directory="$HOME/Notebooks/"
jetson@jnmouse:~/jnm_jupyternotebook/jnmouse/utils$ ls
create_jupyter_service.py  __init__.py  jnmouse_jupyter.service  utils.py
jetson@jnmouse:~/jnm_jupyternotebook/jnmouse/utils$ cat jnmouse_jupyter.service  
[Unit]
Description=Jupyter Notebook Service

[Service]
Type=simple
User=jetson
ExecStart=/bin/sh -c "jupyter lab --ip=0.0.0.0 --no-browser"
WorkingDirectory=/home/jetson/Notebooks/
Restart=always

[Install]
WantedBy=multi-user.target
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
